### PR TITLE
Removed PrivacyTools.io links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,6 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 ## Related
 
-- [Recommended browser add-ons from PrivacyTools.io](https://www.privacytools.io/browsers/#addons).
-- [Firefox's Privacy Related "about:config" Tweaks](https://www.privacytools.io/browsers/#about_config).
 - [Awesome browser extensions for GitHub](https://github.com/stefanbuck/awesome-browser-extensions-for-github).
 
 [![CC4](https://img.shields.io/badge/license-CC4-0a0a0a.svg?style=flat&colorA=0a0a0a)](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
PT.io should not be recommended because of the reason mentioned in this page below:

https://blog.privacyguides.org/2021/09/14/welcome-to-privacy-guides/